### PR TITLE
Fix typo in Humidity Sensor Code

### DIFF
--- a/lib/temperature_and_humidity_sensor_accessory.js
+++ b/lib/temperature_and_humidity_sensor_accessory.js
@@ -38,7 +38,7 @@ class TemperatureAndHumiditySensorAccessory extends BaseAccessory {
             if (statusMap.code === 'va_temperature') {
                 const temperature = statusMap.value / 10;
                 this.normalAsync(this.service, Characteristic.CurrentTemperature, temperature);
-            } else if (statusMap.code === 'humidity_value') {
+            } else if (statusMap.code === 'va_humidity') {
                 const humidity = statusMap.value;
                 this.normalAsync(this.humidityService, Characteristic.CurrentRelativeHumidity, humidity);
             }


### PR DESCRIPTION
Tuya Return's Status code as `va_humidity`